### PR TITLE
Python 3.11

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   release:
     name: Create Release Asset
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,8 +26,7 @@ jobs:
           echo "WHEEL_PATH=${WHEEL_PATH}" >> $GITHUB_ENV
 
       - name: Release
-        uses: softprops/action-gh-release@v0.1.14
-        if: startsWith(github.ref, 'refs/tags/v')
+        uses: crazy-max/ghaction-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,13 +29,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.6", "pypy-3.7", "pypy-3.8", "pypy-3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.8", "pypy-3.9"]
 
     steps:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,8 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, windows-2019, windows-2022]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.6", "pypy-3.7", "pypy-3.8"]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.6", "pypy-3.7", "pypy-3.8", "pypy-3.9"]
 
     steps:
     - uses: actions/checkout@v3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,10 +1,10 @@
 -r requirements.txt
-coverage >= 6.2
-pytest >= 7.0.1
-pytest-cov >= 3.0.0
+coverage >= 6.5.0
+pytest >= 7.2.0
+pytest-cov >= 4.0.0
 coveralls >= 3.3.1
-sphinx >= 4.4.0
-bandit >= 1.7.1
-black >= 22.1.0
-flake8 >= 3.9.2
-pylint >= 2.13.0
+sphinx >= 5.3.0
+bandit >= 1.7.4
+black >= 22.10.0
+flake8 >= 5.0.4
+pylint >= 2.15.6

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: Implementation :: PyPy',
             'Programming Language :: Python :: Implementation :: CPython'
         ],


### PR DESCRIPTION
## Added Features

* Adds support for testing with Python 3.11 and PyPy 3.9

## Bug Fixes

## Related Issues

Note this does remove testing for Python and PyPy with versions 3.6 & 3.7

- [ ] Released Need - Not unless we want to update the labels. Given there are no code changes not sure if it is worth a bump.