### PR TITLE
populate request.postData and response.content.encoding in HarEntry

### DIFF
--- a/haralyzer/http.py
+++ b/haralyzer/http.py
@@ -270,12 +270,12 @@ class Response(HttpTransaction):
         return self.raw_entry["content"]["mimeType"]
 
     @cached_property
-    def text(self) -> Optional[str]:
+    def text(self) -> str:
         """
         :return: Response body
         :rtype: str
         """
-        return self.raw_entry["content"].get("text")
+        return self.raw_entry["content"]["text"]
 
     @cached_property
     def textEncoding(self) -> str:

--- a/haralyzer/http.py
+++ b/haralyzer/http.py
@@ -270,9 +270,17 @@ class Response(HttpTransaction):
         return self.raw_entry["content"]["mimeType"]
 
     @cached_property
-    def text(self) -> str:
+    def text(self) -> Optional[str]:
         """
         :return: Response body
         :rtype: str
         """
-        return self.raw_entry["content"]["text"]
+        return self.raw_entry["content"].get("text")
+
+    @cached_property
+    def textEncoding(self) -> str:
+        """
+        :return: How the response body is encoded
+        :rtype: str
+        """
+        return self.raw_entry["content"].get("encoding")

--- a/haralyzer/http.py
+++ b/haralyzer/http.py
@@ -121,6 +121,26 @@ class Request(HttpTransaction):
         """
         return self.get_header_value("User-Agent")
 
+    @cached_property
+    def mimeType(self) -> Optional[str]:
+        """
+        :return: Mime Type of request
+        :rtype: str
+        """
+        if "postData" not in self.raw_entry:
+            return None
+        return self.raw_entry["postData"].get("mimeType")
+
+    @cached_property
+    def text(self) -> Optional[str]:
+        """
+        :return: Request body
+        :rtype: str
+        """
+        if "postData" not in self.raw_entry:
+            return None
+        return self.raw_entry["postData"].get("text")
+
 
 class Response(HttpTransaction):
     """Response object for a HarEntry"""

--- a/tests/chrome/test_chrome_entry.py
+++ b/tests/chrome/test_chrome_entry.py
@@ -74,6 +74,41 @@ def test_request(har_data):
         == "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 "
         "Safari/537.36"
     )
+    assert request.mimeType is None
+    assert request.text is None
+
+    assert request.get_header_value("Connection") is None
+
+
+def test_request_post(har_data):
+    """
+    Tests that HarEntry.request has the correct POST data
+    """
+    init_data = har_data("chrome.har")
+    request = HarPage(PAGE_ID, har_data=init_data).entries[30].request
+    assert str(request) == "HarEntry.Request for https://jwhite.report-uri.com/r/d/csp/enforce"
+    assert repr(request) == "HarEntry.Request for https://jwhite.report-uri.com/r/d/csp/enforce"
+
+    assert request.accept == "*/*"
+    assert request.cookies == []
+    assert request.bodySize == 1034
+    assert request.cacheControl == "no-cache"
+    assert request.encoding == "gzip, deflate, br"
+    assert len(request.headers) == 17
+    assert request.headersSize == -1
+    assert request.host is None
+    assert request.httpVersion == "http/2.0"
+    assert request.language == "en-US,en;q=0.9"
+    assert request.method == "POST"
+    assert len(request.queryString) == 0
+    assert request.url == "https://jwhite.report-uri.com/r/d/csp/enforce"
+    assert (
+        request.userAgent
+        == "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 "
+        "Safari/537.36"
+    )
+    assert request.mimeType == "application/csp-report"
+    assert len(request.text) == 1034
 
     assert request.get_header_value("Connection") is None
 

--- a/tests/chrome/test_chrome_entry.py
+++ b/tests/chrome/test_chrome_entry.py
@@ -133,8 +133,34 @@ def test_response(har_data):
     assert response.redirectURL == "https://www.jwhite.network"
     assert response.status == 301
     assert response.statusText == ""
-    with pytest.raises(KeyError):
-        assert len(response.text)
+    assert response.text is None
+
+    assert response.get_header_value("Server") == "cloudflare"
+
+
+def test_response_encoded(har_data):
+    """
+    Tests the HarEntry.response has the correct data with encoded content
+    """
+    init_data = har_data("chrome.har")
+    response = HarPage(PAGE_ID, har_data=init_data).entries[9].response
+
+    assert response.bodySize == -1
+    assert response.cacheControl == "max-age=31536000"
+    assert len(response.contentSecurityPolicy) == 654
+    assert response.contentSize == 31485
+    assert response.contentType == "image/png"
+    assert response.date == "Thu, 24 Sep 2020 22:22:57 GMT"
+    assert len(response.headers) == 32
+    assert response.headersSize == -1
+    assert response.httpVersion == "http/2.0"
+    assert response.lastModified == "Sat, 29 Aug 2020 20:36:06 GMT"
+    assert response.mimeType == "image/png"
+    assert response.redirectURL == ""
+    assert response.status == 200
+    assert response.statusText == ""
+    assert len(response.text) == 41980
+    assert response.textEncoding == "base64"
 
     assert response.get_header_value("Server") == "cloudflare"
 

--- a/tests/chrome/test_chrome_entry.py
+++ b/tests/chrome/test_chrome_entry.py
@@ -133,7 +133,8 @@ def test_response(har_data):
     assert response.redirectURL == "https://www.jwhite.network"
     assert response.status == 301
     assert response.statusText == ""
-    assert response.text is None
+    with pytest.raises(KeyError):
+        assert len(response.text)
 
     assert response.get_header_value("Server") == "cloudflare"
 

--- a/tests/firefox/test_firefox_entry.py
+++ b/tests/firefox/test_firefox_entry.py
@@ -65,6 +65,40 @@ def test_request(har_data):
         request.userAgent
         == "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:81.0) Gecko/20100101 Firefox/81.0"
     )
+    assert request.mimeType is None
+    assert request.text is None
+
+    assert request.get_header_value("Connection") == "keep-alive"
+
+
+def test_request_post(har_data):
+    """
+    Tests that HarEntry.request has the correct POST data
+    """
+    init_data = har_data("firefox.har")
+    request = HarPage(PAGE_ID, har_data=init_data).entries[26].request
+    assert str(request) == "HarEntry.Request for https://jwhite.report-uri.com/r/d/csp/enforce"
+    assert repr(request) == "HarEntry.Request for https://jwhite.report-uri.com/r/d/csp/enforce"
+
+    assert request.accept == "*/*"
+    assert request.cookies == []
+    assert request.bodySize == 929
+    assert request.cacheControl is None
+    assert request.encoding == "gzip, deflate, br"
+    assert len(request.headers) == 9
+    assert request.headersSize == 356
+    assert request.host == "jwhite.report-uri.com"
+    assert request.httpVersion == "HTTP/2"
+    assert request.language == "en-US,en;q=0.5"
+    assert request.method == "POST"
+    assert len(request.queryString) == 0
+    assert request.url == "https://jwhite.report-uri.com/r/d/csp/enforce"
+    assert (
+        request.userAgent
+        == "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:81.0) Gecko/20100101 Firefox/81.0"
+    )
+    assert request.mimeType == "application/csp-report"
+    assert len(request.text) == 929
 
     assert request.get_header_value("Connection") == "keep-alive"
 

--- a/tests/firefox/test_firefox_entry.py
+++ b/tests/firefox/test_firefox_entry.py
@@ -131,6 +131,32 @@ def test_response(har_data):
     assert response.get_header_value("Server") == "cloudflare"
 
 
+def test_response_encoded(har_data):
+    """
+    Tests the HarEntry.response has the correct data with encoded content
+    """
+    init_data = har_data("firefox.har")
+    response = HarPage(PAGE_ID, har_data=init_data).entries[9].response
+    assert response.bodySize == 33902
+    assert response.cacheControl == "max-age=31536000"
+    assert len(response.contentSecurityPolicy) == 654
+    assert response.contentSize == 31485
+    assert response.contentType == "image/png"
+    assert response.date == "Thu, 24 Sep 2020 22:21:47 GMT"
+    assert len(response.headers) == 32
+    assert response.headersSize == 2417
+    assert response.httpVersion == "HTTP/2"
+    assert response.lastModified == "Sat, 29 Aug 2020 20:36:06 GMT"
+    assert response.mimeType == "image/png"
+    assert response.redirectURL == ""
+    assert response.status == 200
+    assert response.statusText == "OK"
+    assert len(response.text) == 41980
+    assert response.textEncoding == "base64"
+
+    assert response.get_header_value("Server") == "cloudflare"
+
+
 def test_backwards(har_data):
     """
     Tests that HarEntry class works if expecting dictionary.

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -64,6 +64,8 @@ def test_request(har_data):
         request.userAgent
         == "Mozilla/5.0 (X11; Linux i686 on x86_64; rv:25.0) Gecko/20100101 Firefox/25.0"
     )
+    assert request.mimeType is None
+    assert request.text is None
 
     assert request.get_header_value("Connection") == "keep-alive"
 

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -93,6 +93,7 @@ def test_response(har_data):
     assert response.status == 200
     assert response.statusText == "OK"
     assert len(response.text) == 308
+    assert response.textEncoding is None
 
     assert response.get_header_value("Server") == "nginx"
 


### PR DESCRIPTION
## Added Features

- request.postData
it would be great to populate request.postData in HarEntry as response.content done.
I picked up only "mimeType" and "text" as sub properties (I mean I skipped "params" and "comment").
- response.content.encoding
I also populate how response content is encoded. it's necessary for users to analyze the actual response content.