### PR TITLE
Switch to using coveralls with GitHub token vs repo token

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -89,7 +89,11 @@ jobs:
   Finish:
     needs: Lint
     runs-on: ubuntu-latest
+    container: python:3-slim
     steps:
-      - name: Coveralls Finished
-        run: |
-          curl https://coveralls.io/webhook?repo_token=${{ secrets.GITHUB_TOKEN }} -d "payload[build_num]=${{ github.sha }}&payload[status]=done"
+        - name: Report Coveralls finished
+          run: |
+            pip3 install --upgrade coveralls
+            coveralls --service=github --finish
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -79,11 +79,11 @@ jobs:
       run: make test
 
     - name: Report to Coveralls
-      run: coveralls
+      run: coveralls --service=github
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS }}
         COVERALLS_FLAG_NAME: ${{ matrix.os }}-${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
   Finish:
@@ -92,4 +92,4 @@ jobs:
     steps:
       - name: Coveralls Finished
         run: |
-          curl https://coveralls.io/webhook?repo_token=${{ secrets.COVERALLS }} -d "payload[build_num]=${{ github.sha }}&payload[status]=done"
+          curl https://coveralls.io/webhook?repo_token=${{ secrets.GITHUB_TOKEN }} -d "payload[build_num]=${{ github.sha }}&payload[status]=done"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -68,7 +68,7 @@ jobs:
         pip install . -r requirements_dev.txt
 
     - name: Lint
-      if: matrix.python-version != 'pypy-3.6'
+      if: contains(fromJSON(['pypy-3.6', 'pypy-3.9']), matrix.python-version)
       run: make lint
 
     - name: Check Build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -44,14 +44,14 @@ jobs:
       if: startsWith(runner.os, 'Linux')
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ matrix.python-version}}-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txts') }}
+        key: ${{ runner.os }}-${{ matrix.python-version}}-${{ hashFiles('**/requirements.txt', '**/requirements_dev.txt') }}
 
     - name: MacOS Cache
       uses: actions/cache@v3
       if: startsWith(runner.os, 'macOS')
       with:
         path: ~/Library/Caches/pip
-        key: ${{ runner.os }}-${{ matrix.python-version}}-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txts') }}
+        key: ${{ runner.os }}-${{ matrix.python-version}}-${{ hashFiles('**/requirements.txt', '**/requirements_dev.txt') }}
 
 
     - name: Windows Cache
@@ -59,7 +59,7 @@ jobs:
       if: startsWith(runner.os, 'Windows')
       with:
         path: ~\AppData\Local\pip\Cache
-        key: ${{ runner.os }}-${{ matrix.python-version}}-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txts') }}
+        key: ${{ runner.os }}-${{ matrix.python-version}}-${{ hashFiles('**/requirements.txt', '**/requirements_dev.txt') }}
 
 
     - name: Install Dependencies
@@ -68,7 +68,7 @@ jobs:
         pip install . -r requirements_dev.txt
 
     - name: Lint
-      if: contains(fromJSON('["pypy-3.6", "pypy-3.9"]'), matrix.python-version)
+      if: contains(fromJSON('["pypy-3.9"]'), matrix.python-version) != true && contains(fromJSON('["windows-2019", "windows-2022" ,"macos-12"]'), matrix.os)
       run: make lint
 
     - name: Check Build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -68,7 +68,7 @@ jobs:
         pip install . -r requirements_dev.txt
 
     - name: Lint
-      if: contains(fromJSON(['pypy-3.6', 'pypy-3.9']), matrix.python-version)
+      if: contains(fromJSON('["pypy-3.6", "pypy-3.9"]'), matrix.python-version)
       run: make lint
 
     - name: Check Build


### PR DESCRIPTION
## Added Features

- Use `${{ secrets.GITHUB_TOKEN }}` for coveralls reporting. It is now the recommended way