### PR TITLE
http: Fix KeyError exceptions

### DIFF
--- a/haralyzer/http.py
+++ b/haralyzer/http.py
@@ -146,7 +146,8 @@ class Request(HttpTransaction):
         """
         if "postData" not in self.raw_entry:
             return None
-        return self.raw_entry["postData"].get("text")
+        post_data = self.raw_entry["postData"]
+        return post_data.get("_textBase64", post_data.get("text"))
 
 
 class Response(HttpTransaction):


### PR DESCRIPTION
## Bug Fixes

Fix KeyError exceptions caused by insecure access to `raw_entry['content'][somekey]` while `raw_entry['content'] not exists`